### PR TITLE
Fix error when '=' is used in the dpdk-extra

### DIFF
--- a/plugins/modules/openvswitch_db.py
+++ b/plugins/modules/openvswitch_db.py
@@ -164,7 +164,7 @@ def map_config_to_obj(module):
     col_value_to_dict = {}
     if NON_EMPTY_MAP_RE.match(col_value):
         for kv in col_value[1:-1].split(", "):
-            k, v = kv.split("=")
+            k, v = kv.split("=", 1)
             col_value_to_dict[k.strip()] = v.strip('"')
 
     obj = {


### PR DESCRIPTION
##### SUMMARY
other_config:dpdk-extra contains the extra parameters
that has to be provided to DPDK via OvS. When the
extra parameters contains '=', split will results
in error (other_config:dpdk-extra="--iova-mode=va".
Modify the split to split based on the first occurrence
of equals symbol.

Fixes: ansible/ansible#60993

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
openvswitch_db

##### ADDITIONAL INFORMATION

