### PR TITLE
Allow deleting key from db without specifying value

### DIFF
--- a/changelogs/fragments/fix_openvswitch_db.yaml
+++ b/changelogs/fragments/fix_openvswitch_db.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Allow deleting key from table without specifying value (https://github.com/ansible-collections/openvswitch.openvswitch/issues/64).

--- a/tests/unit/modules/network/ovs/test_openvswitch_db.py
+++ b/tests/unit/modules/network/ovs/test_openvswitch_db.py
@@ -150,6 +150,25 @@ class TestOpenVSwitchDBModule(TestOpenVSwitchModule):
             test_name="test_openvswitch_db_absent_removes_key",
         )
 
+    def test_openvswitch_db_absent_removes_key_no_value(self):
+        set_module_args(
+            dict(
+                state="absent",
+                table="Bridge",
+                record="test-br",
+                col="other_config",
+                key="disable-in-band",
+            )
+        )
+        self.execute_module(
+            changed=True,
+            commands=[
+                "/usr/bin/ovs-vsctl -t 5 remove Bridge test-br other_config"
+                " disable-in-band"
+            ],
+            test_name="test_openvswitch_db_absent_removes_key",
+        )
+
     def test_openvswitch_db_present_idempotent(self):
         set_module_args(
             dict(


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- Fixes #64 
- Based on the observation in https://gist.github.com/NilashishC/2f649bdcd8000e236a09024f7b7ffa14, this is possible from the cli.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
openvswitch_db.py
