### PR TITLE
Fix validate-modules failure

### DIFF
--- a/changelogs/fragments/fix_validate_modules.yaml
+++ b/changelogs/fragments/fix_validate_modules.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Fix failing validate-modules test.

--- a/plugins/modules/openvswitch_db.py
+++ b/plugins/modules/openvswitch_db.py
@@ -214,7 +214,7 @@ def main():
         "table": {"required": True},
         "record": {"required": True},
         "col": {"required": True},
-        "key": {"required": False},
+        "key": {"required": False, "no_log": False},
         "value": {"type": "str"},
         "timeout": {"default": 5, "type": "int"},
     }


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

The argument `key` in the openvswitch_db module identifies the key in the record column, when the column is a map type and is not a sensitive key.