### PR TITLE
Allow VLAN bridges to be idempotent

### DIFF
--- a/changelogs/fragments/fix_vlan_bridge_idempotency.yaml
+++ b/changelogs/fragments/fix_vlan_bridge_idempotency.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "`openvswitch_bridge` - Fix idempotency for VLAN bridges"

--- a/plugins/modules/openvswitch_bridge.py
+++ b/plugins/modules/openvswitch_bridge.py
@@ -87,6 +87,7 @@ EXAMPLES = """
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six import iteritems
+from ansible.module_utils._text import to_text
 
 
 def _fail_mode_to_str(text):
@@ -147,7 +148,7 @@ def map_obj_to_commands(want, have, module):
                             command += " " + k + " " + v
                             commands.append(command)
 
-            if want["vlan"] and want["vlan"] != have["vlan"]:
+            if want["vlan"] and to_text(want["vlan"]) != have["vlan"]:
                 templatized_command = (
                     "%(ovs-vsctl)s -t %(timeout)s"
                     " set port %(bridge)s tag=%(vlan)s"

--- a/tests/integration/targets/openvswitch_bridge/tests/basic.yaml
+++ b/tests/integration/targets/openvswitch_bridge/tests/basic.yaml
@@ -48,6 +48,18 @@
     that:
       - result is changed
 
+- name: Change fake bridge vlan again (idempotent)
+  register: result
+  become: true
+  openvswitch.openvswitch.openvswitch_bridge:
+    bridge: fake-br-test
+    parent: br-test
+    vlan: 300
+
+- assert:
+    that:
+      - result is not changed
+
 - name: Tear down test bridges
   become: true
   command: ovs-vsctl del-br br-test


### PR DESCRIPTION
Managing bridges for VLAN child bridges is not currently idempotent and is being applied on each run. PR fixes and adds a test case, which fails on current main branch.

```
- name: add vlan bridges
  openvswitch.openvswitch.openvswitch_bridge:
    bridge: vlan5
    parent: ovs0
    vlan: 5
    state: present
```

Debugging the have vs want results we can see that the have vlan is a string.

```
root@tank:/tmp# diff debug-have-vlan17 debug-want-vlan17
1c1
< {"bridge": "vlan17", "parent": "ovs0", "vlan": "17", "fail_mode": null, "external_ids": null}
\ No newline at end of file
---
> {"bridge": "vlan17", "parent": "ovs0", "vlan": 17, "fail_mode": null, "external_ids": null, "set": null}
\ No newline at end of file
```

