### PR TITLE
Fix ansible-lint errors

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -12,4 +12,10 @@ rules:
   brackets:
     max-spaces-inside: 1
     level: error
+  comments:
+    min-spaces-from-content: 1
+  comments-indentation: false
+  octal-values:
+    forbid-implicit-octal: true
+    forbid-explicit-octal: true
   line-length: disable

--- a/changelogs/fragments/remove_newline_openvswitch_port.yaml
+++ b/changelogs/fragments/remove_newline_openvswitch_port.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Remove extra newline in openvswitch_port docs

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -6,7 +6,7 @@ name: openvswitch
 tags: [networking, vswitch, bridge, vlan]
 # NOTE(pabelanger): We create an empty version key to keep ansible-galaxy
 # happy. We dynamically inject version info based on git information.
-version: 2.1.2-dev
+version: 2.2.0-dev
 namespace: openvswitch
 readme: README.md
 description: Ansible Network Collection for Open vSwitch

--- a/plugins/modules/openvswitch_port.py
+++ b/plugins/modules/openvswitch_port.py
@@ -106,7 +106,6 @@ EXAMPLES = """
     port: veth0
     state: present
     database_socket: unix:/opt/second_ovsdb.sock
-
 """
 
 from ansible.module_utils.basic import AnsibleModule

--- a/tests/integration/targets/prepare_ovs_tests/tasks/main.yml
+++ b/tests/integration/targets/prepare_ovs_tests/tasks/main.yml
@@ -19,7 +19,7 @@
       when: ansible_distribution == 'Ubuntu'
 
     - name: Install openvswitch package if we are on Fedora
-      ansible.builtin.yum:
+      ansible.builtin.dnf:
         name: openvswitch
         state: installed
         update_cache: true


### PR DESCRIPTION
WARNING  Found incompatible custom yamllint configuration (.yamllint), please either remove the file or edit it to comply with:
  - comments.min-spaces-from-content must be 1
  - comments-indentation must be false
  - octal-values.forbid-implicit-octal must be true
  - octal-values.forbid-explicit-octal must be true.

Read https://docs.ansible.com/projects/lint/rules/yaml/ for more details regarding why we have these requirements. Fix mode will not be available.
WARNING  Listing 2 violation(s) that are fatal
Error: Too many blank lines (1 > 0)
Error: Use FQCN for builtin module actions (ansible.builtin.yum).
Read documentation for instructions on how to ignore specific rule violations.

# Rule Violation Summary

  1 yaml profile:basic tags:formatting,yaml
  1 fqcn profile:basic tags:formatting

Failed: 2 failure(s), 0 warning(s) in 50 files processed of 84 encountered. Last profile that met the validation criteria was 'min'.
yaml[empty-lines]: Too many blank lines (1 > 0)
plugins/modules/openvswitch_port.py:109

fqcn[action-core]: Use FQCN for builtin module actions (ansible.builtin.yum).
tests/integration/targets/prepare_ovs_tests/tasks/main.yml:22:7 Use `ansible.builtin.dnf` or `ansible.legacy.dnf` instead.