### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,50 @@
+---
+name: Publish to Ansible Galaxy
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    name: Publish Collection
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: "test-requirements.txt"
+
+      - name: Install ansible-core
+        run: pip install ansible-core
+
+      - name: Update version in galaxy.yml
+        run: |
+          # Extract tag name, stripping 'v' prefix if present
+          TAG_NAME="${{ github.event.release.tag_name }}"
+          VERSION="${TAG_NAME#v}"
+          sed -i "s/^version: .*/version: ${VERSION}/" galaxy.yml
+          echo "GALAXY_VERSION=${VERSION}" >> ${GITHUB_ENV}
+
+      - name: Build Ansible Collection
+        run: ansible-galaxy collection build
+
+      - name: Upload Artifact to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            openvswitch-openvswitch-${{ env.GALAXY_VERSION }}.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish Ansible Collection to Galaxy
+        env:
+          ANSIBLE_GALAXY_TOKEN: ${{ secrets.GALAXY_API_KEY }}
+        run: ansible-galaxy collection publish "openvswitch-openvswitch-${{ env.GALAXY_VERSION }}.tar.gz" --api-key "$ANSIBLE_GALAXY_TOKEN"


### PR DESCRIPTION
Whenever we issue a new release on a Github, this workflow will be triggered and publish a collection to the Galaxy.

Signed-off-by: Dmitriy Rabotyagov <noonedeadpunk@gmail.com>