### PR TITLE
Update tested Ansible versions in readme

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,8 +12,6 @@ on:  # yamllint disable-line rule:truthy
   schedule:
     - cron: '0 0 * * *'
 
-# Due to an issue in GHA runner, MATRIX_EXCLUDE is set as an environment variable
-# https://github.com/actions/runner/issues/2372
 jobs:
   ansible-lint:
     uses: ansible-network/github_actions/.github/workflows/ansible-lint.yml@main
@@ -22,19 +20,14 @@ jobs:
     if: github.event_name == 'pull_request'
   sanity:
     uses: ansible-network/github_actions/.github/workflows/sanity.yml@main
-    with:
-      matrix_exclude: ${{ vars.MATRIX_EXCLUDE }}
   unit-galaxy:
     uses: ansible-network/github_actions/.github/workflows/unit_galaxy.yml@main
-    with:
-      matrix_exclude: ${{ vars.MATRIX_EXCLUDE }}
   unit-source:
     uses: ansible-network/github_actions/.github/workflows/unit_source.yml@main
     with:
       collection_pre_install: >-
         git+https://github.com/ansible-collections/ansible.utils.git
         git+https://github.com/ansible-collections/ansible.netcommon.git
-      matrix_exclude: ${{ vars.MATRIX_EXCLUDE }}
   all_green:
     if: ${{ always() && (github.event_name != 'schedule') }}
     needs:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,32 @@ Openvswitch Collection Release Notes
 
 .. contents:: Topics
 
+v2.2.1
+======
+
+Minor Changes
+-------------
+
+- Added support for ansible-core 2.21
+
+Breaking Changes / Porting Guide
+--------------------------------
+
+- Minimum required ansible-core version is now 2.16
+
+v2.2.0
+======
+
+Minor Changes
+-------------
+
+- Added support for ansible-core 2.18, 2.19 and 2.20
+- Remove extra newline in openvswitch_port docs
+
+Breaking Changes / Porting Guide
+--------------------------------
+
+- Minimum required ansible-core version is now 2.15
 
 v2.1.1
 ======

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The Open vSwitch collection includes a variety of Ansible content to help automa
 <!--start requires_ansible-->
 ## Ansible version compatibility
 
-This collection has been tested against following Ansible versions: **<2.21.0,>=2.15.0**.
+This collection has been tested against following Ansible versions: **<2.22.0,>=2.16.0**.
 
 Plugins and modules within a collection may be tested with only specific Ansible versions.
 A collection may contain metadata that identifies these versions.

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -2,113 +2,131 @@ ancestor: null
 releases:
   1.0.0:
     modules:
-      - description: Manage Open vSwitch bridges
-        name: openvswitch_bridge
-        namespace: ""
-      - description: Configure open vswitch database.
-        name: openvswitch_db
-        namespace: ""
-      - description: Manage Open vSwitch ports
-        name: openvswitch_port
-        namespace: ""
-    release_date: "2020-06-23"
+    - description: Manage Open vSwitch bridges
+      name: openvswitch_bridge
+      namespace: ''
+    - description: Configure open vswitch database.
+      name: openvswitch_db
+      namespace: ''
+    - description: Manage Open vSwitch ports
+      name: openvswitch_port
+      namespace: ''
+    release_date: '2020-06-23'
   1.0.1:
     changes:
       bugfixes:
-        - Makes sure that docstring and argspec are in sync and removes sanity ignores
-          (https://github.com/ansible-collections/openvswitch.openvswitch/pull/46).
-        - Update docs after sanity fixes to modules.
+      - Makes sure that docstring and argspec are in sync and removes sanity ignores
+        (https://github.com/ansible-collections/openvswitch.openvswitch/pull/46).
+      - Update docs after sanity fixes to modules.
     fragments:
-      - remove_ignores.yaml
-      - update_docs.yaml
-    release_date: "2020-08-03"
+    - remove_ignores.yaml
+    - update_docs.yaml
+    release_date: '2020-08-03'
   1.0.2:
     changes:
       release_summary: Rereleased 1.0.1 with updated changelog.
     fragments:
-      - 1.0.2.yaml
-    release_date: "2020-08-07"
+    - 1.0.2.yaml
+    release_date: '2020-08-07'
   1.0.3:
     changes:
       release_summary: Released for testing.
     fragments:
-      - 1.0.3.yaml
-    release_date: "2020-08-07"
+    - 1.0.3.yaml
+    release_date: '2020-08-07'
   1.0.4:
     changes:
       release_summary: Rereleased 1.0.3 with updated changelog.
     fragments:
-      - 1.0.4.yaml
-    release_date: "2020-08-08"
+    - 1.0.4.yaml
+    release_date: '2020-08-08'
   1.0.5:
     changes:
       minor_changes:
-        - Regenerated docs, add description to galaxy.yml and linked changelog to README
-          (https://github.com/ansible-collections/openvswitch.openvswitch/pull/53).
+      - Regenerated docs, add description to galaxy.yml and linked changelog to README
+        (https://github.com/ansible-collections/openvswitch.openvswitch/pull/53).
     fragments:
-      - fixes_to_readme_and_doc.yaml
-    release_date: "2020-08-28"
+    - fixes_to_readme_and_doc.yaml
+    release_date: '2020-08-28'
   1.1.0:
     changes:
       bugfixes:
-        - Add version key to galaxy.yaml to work around ansible-galaxy bug (https://github.com/ansible-collections/openvswitch.openvswitch/issues/59)
+      - Add version key to galaxy.yaml to work around ansible-galaxy bug (https://github.com/ansible-collections/openvswitch.openvswitch/issues/59)
       minor_changes:
-        - openvswitch_bond - New module for managing Open vSwitch bonds (https://github.com/ansible-collections/openvswitch.openvswitch/pull/58).
+      - openvswitch_bond - New module for managing Open vSwitch bonds (https://github.com/ansible-collections/openvswitch.openvswitch/pull/58).
     fragments:
-      - 1-openvswitch_bond-new-module.yaml
-      - fix_download_git.yaml
-    release_date: "2020-11-26"
+    - 1-openvswitch_bond-new-module.yaml
+    - fix_download_git.yaml
+    release_date: '2020-11-26'
   1.2.0:
     changes:
       bugfixes:
-        - Allow deleting key from table without specifying value (https://github.com/ansible-collections/openvswitch.openvswitch/issues/64).
+      - Allow deleting key from table without specifying value (https://github.com/ansible-collections/openvswitch.openvswitch/issues/64).
       minor_changes:
-        - Allow setting multiple properties on a port (https://github.com/ansible-collections/openvswitch.openvswitch/issues/63).
+      - Allow setting multiple properties on a port (https://github.com/ansible-collections/openvswitch.openvswitch/issues/63).
     fragments:
-      - fix_openvswitch_db.yaml
-      - fix_openvswitch_port.yaml
-    release_date: "2021-02-24"
+    - fix_openvswitch_db.yaml
+    - fix_openvswitch_port.yaml
+    release_date: '2021-02-24'
   2.0.0:
     changes:
       major_changes:
-        - There is no major changes for this particular release and it was tagged by
-          mistake and cannot be reverted.
-    release_date: "2021-02-24"
+      - There is no major changes for this particular release and it was tagged by
+        mistake and cannot be reverted.
+    release_date: '2021-02-24'
   2.0.1:
     changes:
       major_changes:
-        - By mistake we tagged the repo to 2.0.0 and as it wasn't intended and cannot
-          be reverted we're releasing 2.0.1 to make the community aware of the major
-          version update.
-    release_date: "2021-03-03"
+      - By mistake we tagged the repo to 2.0.0 and as it wasn't intended and cannot
+        be reverted we're releasing 2.0.1 to make the community aware of the major
+        version update.
+    release_date: '2021-03-03'
   2.0.2:
     changes:
       bugfixes:
-        - "`openvswitch_bridge` - Fix idempotency for VLAN bridges"
+      - '`openvswitch_bridge` - Fix idempotency for VLAN bridges'
     fragments:
-      - 69-remove_tests_sanity_requirements.yml
-      - fix_validate_modules.yaml
-      - fix_vlan_bridge_idempotency.yaml
-      - pylint_fixes.yaml
-    release_date: "2021-09-24"
+    - 69-remove_tests_sanity_requirements.yml
+    - fix_validate_modules.yaml
+    - fix_vlan_bridge_idempotency.yaml
+    - pylint_fixes.yaml
+    release_date: '2021-09-24'
   2.1.0:
     changes:
       minor_changes:
-        - Allows read operation in openvswitch_db module(https://github.com/ansible-collections/openvswitch.openvswitch/pull/88)
-        - openvswitch modules got support for database socket parameter.
+      - Allows read operation in openvswitch_db module(https://github.com/ansible-collections/openvswitch.openvswitch/pull/88)
+      - openvswitch modules got support for database socket parameter.
     fragments:
-      - 84-ovs-modules-database-socket.yaml
-      - openvswitch_db_read.yaml
-    release_date: "2021-12-07"
+    - 84-ovs-modules-database-socket.yaml
+    - openvswitch_db_read.yaml
+    release_date: '2021-12-07'
   2.1.1:
     changes:
       bugfixes:
-        - Fix galaxy version issue when installing this collection.
+      - Fix galaxy version issue when installing this collection.
       doc_changes:
-        - Update module documentation and examples.
+      - Update module documentation and examples.
     fragments:
-      - black.yaml
-      - fix.yaml
-      - galaxy.yml
-      - gha.yaml
-    release_date: "2023-04-27"
+    - black.yaml
+    - fix.yaml
+    - galaxy.yml
+    - gha.yaml
+    release_date: '2023-04-27'
+  2.2.0:
+    changes:
+      breaking_changes:
+      - Minimum required ansible-core version is now 2.15
+      minor_changes:
+      - Added support for ansible-core 2.18, 2.19 and 2.20
+      - Remove extra newline in openvswitch_port docs
+    fragments:
+    - add_gha_periodic.yaml
+    - ansible_versions_changes.yaml
+    - remove_newline_openvswitch_port.yaml
+    release_date: '2026-04-16'
+  2.2.1:
+    changes:
+      breaking_changes:
+      - Minimum required ansible-core version is now 2.16
+      minor_changes:
+      - Added support for ansible-core 2.21

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -2,131 +2,131 @@ ancestor: null
 releases:
   1.0.0:
     modules:
-    - description: Manage Open vSwitch bridges
-      name: openvswitch_bridge
-      namespace: ''
-    - description: Configure open vswitch database.
-      name: openvswitch_db
-      namespace: ''
-    - description: Manage Open vSwitch ports
-      name: openvswitch_port
-      namespace: ''
-    release_date: '2020-06-23'
+      - description: Manage Open vSwitch bridges
+        name: openvswitch_bridge
+        namespace: ""
+      - description: Configure open vswitch database.
+        name: openvswitch_db
+        namespace: ""
+      - description: Manage Open vSwitch ports
+        name: openvswitch_port
+        namespace: ""
+    release_date: "2020-06-23"
   1.0.1:
     changes:
       bugfixes:
-      - Makes sure that docstring and argspec are in sync and removes sanity ignores
-        (https://github.com/ansible-collections/openvswitch.openvswitch/pull/46).
-      - Update docs after sanity fixes to modules.
+        - Makes sure that docstring and argspec are in sync and removes sanity ignores
+          (https://github.com/ansible-collections/openvswitch.openvswitch/pull/46).
+        - Update docs after sanity fixes to modules.
     fragments:
-    - remove_ignores.yaml
-    - update_docs.yaml
-    release_date: '2020-08-03'
+      - remove_ignores.yaml
+      - update_docs.yaml
+    release_date: "2020-08-03"
   1.0.2:
     changes:
       release_summary: Rereleased 1.0.1 with updated changelog.
     fragments:
-    - 1.0.2.yaml
-    release_date: '2020-08-07'
+      - 1.0.2.yaml
+    release_date: "2020-08-07"
   1.0.3:
     changes:
       release_summary: Released for testing.
     fragments:
-    - 1.0.3.yaml
-    release_date: '2020-08-07'
+      - 1.0.3.yaml
+    release_date: "2020-08-07"
   1.0.4:
     changes:
       release_summary: Rereleased 1.0.3 with updated changelog.
     fragments:
-    - 1.0.4.yaml
-    release_date: '2020-08-08'
+      - 1.0.4.yaml
+    release_date: "2020-08-08"
   1.0.5:
     changes:
       minor_changes:
-      - Regenerated docs, add description to galaxy.yml and linked changelog to README
-        (https://github.com/ansible-collections/openvswitch.openvswitch/pull/53).
+        - Regenerated docs, add description to galaxy.yml and linked changelog to README
+          (https://github.com/ansible-collections/openvswitch.openvswitch/pull/53).
     fragments:
-    - fixes_to_readme_and_doc.yaml
-    release_date: '2020-08-28'
+      - fixes_to_readme_and_doc.yaml
+    release_date: "2020-08-28"
   1.1.0:
     changes:
       bugfixes:
-      - Add version key to galaxy.yaml to work around ansible-galaxy bug (https://github.com/ansible-collections/openvswitch.openvswitch/issues/59)
+        - Add version key to galaxy.yaml to work around ansible-galaxy bug (https://github.com/ansible-collections/openvswitch.openvswitch/issues/59)
       minor_changes:
-      - openvswitch_bond - New module for managing Open vSwitch bonds (https://github.com/ansible-collections/openvswitch.openvswitch/pull/58).
+        - openvswitch_bond - New module for managing Open vSwitch bonds (https://github.com/ansible-collections/openvswitch.openvswitch/pull/58).
     fragments:
-    - 1-openvswitch_bond-new-module.yaml
-    - fix_download_git.yaml
-    release_date: '2020-11-26'
+      - 1-openvswitch_bond-new-module.yaml
+      - fix_download_git.yaml
+    release_date: "2020-11-26"
   1.2.0:
     changes:
       bugfixes:
-      - Allow deleting key from table without specifying value (https://github.com/ansible-collections/openvswitch.openvswitch/issues/64).
+        - Allow deleting key from table without specifying value (https://github.com/ansible-collections/openvswitch.openvswitch/issues/64).
       minor_changes:
-      - Allow setting multiple properties on a port (https://github.com/ansible-collections/openvswitch.openvswitch/issues/63).
+        - Allow setting multiple properties on a port (https://github.com/ansible-collections/openvswitch.openvswitch/issues/63).
     fragments:
-    - fix_openvswitch_db.yaml
-    - fix_openvswitch_port.yaml
-    release_date: '2021-02-24'
+      - fix_openvswitch_db.yaml
+      - fix_openvswitch_port.yaml
+    release_date: "2021-02-24"
   2.0.0:
     changes:
       major_changes:
-      - There is no major changes for this particular release and it was tagged by
-        mistake and cannot be reverted.
-    release_date: '2021-02-24'
+        - There is no major changes for this particular release and it was tagged by
+          mistake and cannot be reverted.
+    release_date: "2021-02-24"
   2.0.1:
     changes:
       major_changes:
-      - By mistake we tagged the repo to 2.0.0 and as it wasn't intended and cannot
-        be reverted we're releasing 2.0.1 to make the community aware of the major
-        version update.
-    release_date: '2021-03-03'
+        - By mistake we tagged the repo to 2.0.0 and as it wasn't intended and cannot
+          be reverted we're releasing 2.0.1 to make the community aware of the major
+          version update.
+    release_date: "2021-03-03"
   2.0.2:
     changes:
       bugfixes:
-      - '`openvswitch_bridge` - Fix idempotency for VLAN bridges'
+        - "`openvswitch_bridge` - Fix idempotency for VLAN bridges"
     fragments:
-    - 69-remove_tests_sanity_requirements.yml
-    - fix_validate_modules.yaml
-    - fix_vlan_bridge_idempotency.yaml
-    - pylint_fixes.yaml
-    release_date: '2021-09-24'
+      - 69-remove_tests_sanity_requirements.yml
+      - fix_validate_modules.yaml
+      - fix_vlan_bridge_idempotency.yaml
+      - pylint_fixes.yaml
+    release_date: "2021-09-24"
   2.1.0:
     changes:
       minor_changes:
-      - Allows read operation in openvswitch_db module(https://github.com/ansible-collections/openvswitch.openvswitch/pull/88)
-      - openvswitch modules got support for database socket parameter.
+        - Allows read operation in openvswitch_db module(https://github.com/ansible-collections/openvswitch.openvswitch/pull/88)
+        - openvswitch modules got support for database socket parameter.
     fragments:
-    - 84-ovs-modules-database-socket.yaml
-    - openvswitch_db_read.yaml
-    release_date: '2021-12-07'
+      - 84-ovs-modules-database-socket.yaml
+      - openvswitch_db_read.yaml
+    release_date: "2021-12-07"
   2.1.1:
     changes:
       bugfixes:
-      - Fix galaxy version issue when installing this collection.
+        - Fix galaxy version issue when installing this collection.
       doc_changes:
-      - Update module documentation and examples.
+        - Update module documentation and examples.
     fragments:
-    - black.yaml
-    - fix.yaml
-    - galaxy.yml
-    - gha.yaml
-    release_date: '2023-04-27'
+      - black.yaml
+      - fix.yaml
+      - galaxy.yml
+      - gha.yaml
+    release_date: "2023-04-27"
   2.2.0:
     changes:
       breaking_changes:
-      - Minimum required ansible-core version is now 2.15
+        - Minimum required ansible-core version is now 2.15
       minor_changes:
-      - Added support for ansible-core 2.18, 2.19 and 2.20
-      - Remove extra newline in openvswitch_port docs
+        - Added support for ansible-core 2.18, 2.19 and 2.20
+        - Remove extra newline in openvswitch_port docs
     fragments:
-    - add_gha_periodic.yaml
-    - ansible_versions_changes.yaml
-    - remove_newline_openvswitch_port.yaml
-    release_date: '2026-04-16'
+      - add_gha_periodic.yaml
+      - ansible_versions_changes.yaml
+      - remove_newline_openvswitch_port.yaml
+    release_date: "2026-04-16"
   2.2.1:
     changes:
       breaking_changes:
-      - Minimum required ansible-core version is now 2.16
+        - Minimum required ansible-core version is now 2.16
       minor_changes:
-      - Added support for ansible-core 2.21
+        - Added support for ansible-core 2.21

--- a/changelogs/fragments/add_gha_periodic.yaml
+++ b/changelogs/fragments/add_gha_periodic.yaml
@@ -1,3 +1,0 @@
----
-trivial:
-  - Enable nightly GHA runs.

--- a/changelogs/fragments/ansible_versions_changes.yaml
+++ b/changelogs/fragments/ansible_versions_changes.yaml
@@ -1,4 +1,0 @@
-breaking_changes:
-  - Minimum required ansible-core version is now 2.15
-minor_changes:
-  - Added support for ansible-core 2.18, 2.19 and 2.20

--- a/changelogs/fragments/remove_newline_openvswitch_port.yaml
+++ b/changelogs/fragments/remove_newline_openvswitch_port.yaml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - Remove extra newline in openvswitch_port docs

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -6,7 +6,7 @@ name: openvswitch
 tags: [networking, vswitch, bridge, vlan]
 # NOTE(pabelanger): We create an empty version key to keep ansible-galaxy
 # happy. We dynamically inject version info based on git information.
-version: 3.0.0-dev
+version: 2.2.1
 namespace: openvswitch
 readme: README.md
 description: Ansible Network Collection for Open vSwitch

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -6,7 +6,7 @@ name: openvswitch
 tags: [networking, vswitch, bridge, vlan]
 # NOTE(pabelanger): We create an empty version key to keep ansible-galaxy
 # happy. We dynamically inject version info based on git information.
-version: 2.2.1
+version: 3.0.0-dev
 namespace: openvswitch
 readme: README.md
 description: Ansible Network Collection for Open vSwitch


### PR DESCRIPTION
With changes to  github_actions[1] defenitions and release of 2.21, we have stopeed testing 2.15, but 2.21 was added to the matrix.

[1] http://github.com/ansible-network/github_actions

Signed-off-by: Dmitriy Rabotyagov <noonedeadpunk@gmail.com>