### PR TITLE
Allow openvswitch_bridge set parameter to accept a list of strings

### DIFF
--- a/changelogs/fragments/117.yaml
+++ b/changelogs/fragments/117.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - openvswitch_bridge - allow the set parameter to accept a list of strings to chain multiple set sub-commands (https://github.com/ansible-collections/openvswitch.openvswitch/issues/117).

--- a/plugins/modules/openvswitch_bridge.py
+++ b/plugins/modules/openvswitch_bridge.py
@@ -58,8 +58,9 @@ options:
   set:
     description:
     - Run set command after bridge configuration. This parameter is non-idempotent,
-      play will always return I(changed) state if present
-    type: str
+      play will always return I(changed) state if present. Accepts a string or a
+      list of strings to chain multiple set sub-commands.
+    type: raw
   database_socket:
     description:
     - Path/ip to datbase socket to use
@@ -94,6 +95,14 @@ EXAMPLES = """
     bridge: br0
     state: present
     database_socket: unix:/opt/second.sock
+
+# Create a bridge with multiple set sub-commands
+- openvswitch.openvswitch.openvswitch_bridge:
+    bridge: br-int
+    state: present
+    set:
+      - Bridge br-int other-config:datapath-id=0000000000000001
+      - Bridge br-int protocols=OpenFlow13
 """
 
 from ansible.module_utils._text import to_text
@@ -165,8 +174,12 @@ def map_obj_to_commands(want, have, module):
                 command += " " + templatized_command % module.params
 
             if want["set"]:
-                templatized_command = " -- set %(set)s"
-                command += templatized_command % module.params
+                set_value = want["set"]
+                if isinstance(set_value, list):
+                    for item in set_value:
+                        command += " -- set " + item
+                else:
+                    command += " -- set " + set_value
 
             commands.append(command)
 
@@ -247,7 +260,7 @@ def main():
         "timeout": {"default": 5, "type": "int"},
         "external_ids": {"default": None, "type": "dict"},
         "fail_mode": {"default": None},
-        "set": {"required": False, "default": None},
+        "set": {"required": False, "default": None, "type": "raw"},
         "database_socket": {"default": None},
     }
 

--- a/tests/unit/modules/network/ovs/test_openvswitch_bridge.py
+++ b/tests/unit/modules/network/ovs/test_openvswitch_bridge.py
@@ -110,6 +110,12 @@ test_name_side_effect_matrix = {
         (0, "", ""),
         (0, "", ""),
     ],
+    "test_openvswitch_bridge_present_runs_set_list_mode": [
+        (0, "", ""),
+        (0, "", ""),
+        (0, "", ""),
+        (0, "", ""),
+    ],
     "test_openvswitch_bridge_absent_removes_bridge_check_mode": [
         (0, "list_br_test_br.cfg", ""),
         (0, "br_to_parent_test_br.cfg", ""),
@@ -321,6 +327,28 @@ class TestOpenVSwitchBridgeModule(TestOpenVSwitchModule):
             changed=True,
             commands=commands,
             test_name="test_openvswitch_bridge_present_runs_set_mode",
+        )
+
+    def test_openvswitch_bridge_present_runs_set_list_mode(self):
+        set_module_args(
+            dict(
+                state="present",
+                bridge="test-br",
+                set=[
+                    "bridge test-br other-config:datapath-id=0000000000000001",
+                    "bridge test-br protocols=OpenFlow13",
+                ],
+            )
+        )
+        commands = [
+            "/usr/bin/ovs-vsctl -t 5 add-br test-br"
+            " -- set bridge test-br other-config:datapath-id=0000000000000001"
+            " -- set bridge test-br protocols=OpenFlow13",
+        ]
+        self.execute_module(
+            changed=True,
+            commands=commands,
+            test_name="test_openvswitch_bridge_present_runs_set_list_mode",
         )
 
     def test_openvswitch_bridge_absent_removes_bridge_check_mode(self):


### PR DESCRIPTION
Change the type to raw to allow both str (backward compatible) and list, with list items chained as separate -- set sub-commands on add-br.

Fixes https://github.com/ansible-collections/openvswitch.openvswitch/issues/117

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
