### PR TITLE
Fix minimal ansible version in metadata

### DIFF
--- a/changelogs/fragments/update_meta.yaml
+++ b/changelogs/fragments/update_meta.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - fixed collection meta defenition with minimal supported ansible version.

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,5 +1,5 @@
 ---
-requires_ansible: ">=2.15.0"
+requires_ansible: ">=2.16.0"
 plugin_routing:
   modules:
     bridge:


### PR DESCRIPTION
In 2.2.1 we have bumped minimal version of ansible-core to 2.16 but this was not reflected in metadata, so in Galaxy it's still claimed to be 2.15 which is not tested.

Signed-off-by: Dmitriy Rabotyagov <noonedeadpunk@gmail.com>
